### PR TITLE
Code cleanup: use enum for Ruckig constant, add utility functions

### DIFF
--- a/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
+++ b/moveit_core/trajectory_processing/include/moveit/trajectory_processing/ruckig_traj_smoothing.h
@@ -42,6 +42,11 @@
 
 namespace trajectory_processing
 {
+namespace
+{
+constexpr size_t RUCKIG_DYNAMIC_DOF = 0;  // Put Ruckig in "dynamic DOF" mode
+}
+
 class RuckigSmoothing
 {
 public:
@@ -58,9 +63,9 @@ private:
    * \param idx             MoveIt list of joint group indices
    * \param ruckig_input    Output. The Rucking parameters for the next iteration
    */
-  static void getNextRuckigInput(const ruckig::OutputParameter<0>& ruckig_output,
+  static void getNextRuckigInput(const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output,
                                  const moveit::core::RobotStatePtr& next_waypoint, size_t num_dof,
-                                 const std::vector<int>& idx, ruckig::InputParameter<0>& ruckig_input);
+                                 const std::vector<int>& idx, ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input);
 
   /**
    * \brief Check for lagging motion of any joint at a waypoint.
@@ -69,15 +74,15 @@ private:
    * \param ruckig_output Output parameters from Ruckig
    * \return              true if lagging motion is detected on any joint
    */
-  static bool checkForLaggingMotion(const size_t num_dof, const ruckig::InputParameter<0>& ruckig_input,
-                                    const ruckig::OutputParameter<0>& ruckig_output);
+  static bool checkForLaggingMotion(const size_t num_dof, const ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input,
+                                    const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output);
 
   /**
    * \brief Return L2-norm of velocity, taking all joints into account.
    * \param ruckig_input  Input parameters to Ruckig
    * \param num_dof       Number  of actuated joints
    */
-  static double getTargetVelocityMagnitude(const ruckig::InputParameter<0>& ruckig_input, size_t num_dof);
+  static double getTargetVelocityMagnitude(const ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input, size_t num_dof);
 
   /**
    * \brief Check if the joint positions of two waypoints are very similar.
@@ -90,6 +95,25 @@ private:
                                          const moveit::core::JointModelGroup* joint_group);
 
   /**
+   * \brief Set position, velocity, and acceleration of a RobotState from a Ruckig output state
+   * \param ruckig_output Output from Ruckig
+   * \param num_dof       Degrees of freedom of the robot
+   * \param state         State to be updated
+   */
+  static void setRobotStateFromRuckigOutput(const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF> ruckig_output,
+                                            const size_t num_dof, const std::vector<int>& joint_idx,
+                                            moveit::core::RobotStatePtr state);
+
+  /**
+   * \brief Decrease ruckig_input.target_velocity and ruckig_input.target_acceleration
+   * \param num_dof       Degrees of freedom of the robot
+   * \param timestep      Ruckig timestep (sec)
+   * \param rucking_input Target state to be adjusted
+   */
+  static void decreaseTargetStateVelocity(const size_t num_dof, const double timestep,
+                                          ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input);
+
+  /**
    * \brief Initialize Ruckig position/vel/accel. This initializes ruckig_input and ruckig_output to the same values
    * \param rucking_input   Input parameters to Ruckig. Initialized here.
    * \param ruckig_output   Output from the Ruckig algorithm. Initialized here.
@@ -97,7 +121,7 @@ private:
    * \param num_dof         Number  of actuated joints
    * \param joint_idx       MoveIt list of joint group indices
    */
-  static void initializeRuckigState(ruckig::InputParameter<0>& ruckig_input, ruckig::OutputParameter<0>& ruckig_output,
+  static void initializeRuckigState(ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input, ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output,
                                     const moveit::core::RobotState& first_waypoint, size_t num_dof,
                                     const std::vector<int>& joint_idx);
 };

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -167,7 +167,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
 
     // If ruckig failed, the duration of the seed trajectory likely wasn't long enough.
     // Try duration extension several times.
-    if (ruckig_result == ruckig::Result::Working)
+    if (ruckig_result == ruckig::Result::Finished)
     {
       smoothing_complete = true;
     }

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -83,10 +83,10 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
 
   // Instantiate the smoother
   double timestep = trajectory.getAverageSegmentDuration();
-  std::unique_ptr<ruckig::Ruckig<0>> ruckig_ptr;
-  ruckig_ptr = std::make_unique<ruckig::Ruckig<0>>(num_dof, timestep);
-  ruckig::InputParameter<0> ruckig_input{ num_dof };
-  ruckig::OutputParameter<0> ruckig_output{ num_dof };
+  std::unique_ptr<ruckig::Ruckig<RUCKIG_DYNAMIC_DOF>> ruckig_ptr;
+  ruckig_ptr = std::make_unique<ruckig::Ruckig<RUCKIG_DYNAMIC_DOF>>(num_dof, timestep);
+  ruckig::InputParameter<RUCKIG_DYNAMIC_DOF> ruckig_input{ num_dof };
+  ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF> ruckig_output{ num_dof };
 
   // Initialize the smoother
   const std::vector<int>& idx = group->getVariableIndexList();
@@ -169,13 +169,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
       }
 
       // Overwrite pos/vel/accel of the target waypoint
-      for (size_t joint = 0; joint < num_dof; ++joint)
-      {
-        next_waypoint->setVariablePosition(idx.at(joint), ruckig_output.new_position.at(joint));
-        next_waypoint->setVariableVelocity(idx.at(joint), ruckig_output.new_velocity.at(joint));
-        next_waypoint->setVariableAcceleration(idx.at(joint), ruckig_output.new_acceleration.at(joint));
-      }
-      next_waypoint->update();
+      setRobotStateFromRuckigOutput(ruckig_output, num_dof, idx, next_waypoint);
     }
 
     // If ruckig failed, the duration of the seed trajectory likely wasn't long enough.
@@ -200,7 +194,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
       }
 
       timestep = trajectory.getAverageSegmentDuration();
-      ruckig_ptr = std::make_unique<ruckig::Ruckig<0>>(num_dof, timestep);
+      ruckig_ptr = std::make_unique<ruckig::Ruckig<RUCKIG_DYNAMIC_DOF>>(num_dof, timestep);
     }
   }
 
@@ -215,8 +209,34 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
   return true;
 }
 
-void RuckigSmoothing::initializeRuckigState(ruckig::InputParameter<0>& ruckig_input,
-                                            ruckig::OutputParameter<0>& ruckig_output,
+void RuckigSmoothing::setRobotStateFromRuckigOutput(const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF> ruckig_output,
+                                                    const size_t num_dof, const std::vector<int>& joint_idx,
+                                                    moveit::core::RobotStatePtr state)
+{
+  for (size_t joint = 0; joint < num_dof; ++joint)
+  {
+    state->setVariablePosition(joint_idx.at(joint), ruckig_output.new_position.at(joint));
+    state->setVariableVelocity(joint_idx.at(joint), ruckig_output.new_velocity.at(joint));
+    state->setVariableAcceleration(joint_idx.at(joint), ruckig_output.new_acceleration.at(joint));
+  }
+  state->update();
+}
+
+void RuckigSmoothing::decreaseTargetStateVelocity(const size_t num_dof, const double timestep,
+                                                  ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input)
+{
+  for (size_t joint = 0; joint < num_dof; ++joint)
+  {
+    ruckig_input.target_velocity.at(joint) *= 0.9;
+    // Propagate the change in velocity to acceleration, too.
+    // We don't change the position to ensure the exact target position is achieved.
+    ruckig_input.target_acceleration.at(joint) =
+        (ruckig_input.target_velocity.at(joint) - ruckig_input.current_velocity.at(joint)) / timestep;
+  }
+}
+
+void RuckigSmoothing::initializeRuckigState(ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input,
+                                            ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output,
                                             const moveit::core::RobotState& first_waypoint, size_t num_dof,
                                             const std::vector<int>& idx)
 {
@@ -248,7 +268,7 @@ bool RuckigSmoothing::checkForIdenticalWaypoints(const moveit::core::RobotState&
   return (magnitude_position_difference <= IDENTICAL_POSITION_EPSILON);
 }
 
-double RuckigSmoothing::getTargetVelocityMagnitude(const ruckig::InputParameter<0>& ruckig_input, size_t num_dof)
+double RuckigSmoothing::getTargetVelocityMagnitude(const ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input, size_t num_dof)
 {
   double vel_magnitude = 0;
   for (size_t joint = 0; joint < num_dof; ++joint)
@@ -258,8 +278,8 @@ double RuckigSmoothing::getTargetVelocityMagnitude(const ruckig::InputParameter<
   return sqrt(vel_magnitude);
 }
 
-bool RuckigSmoothing::checkForLaggingMotion(const size_t num_dof, const ruckig::InputParameter<0>& ruckig_input,
-                                            const ruckig::OutputParameter<0>& ruckig_output)
+bool RuckigSmoothing::checkForLaggingMotion(const size_t num_dof, const ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input,
+                                            const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output)
 {
   // Check for backward motion of any joint
   for (size_t joint = 0; joint < num_dof; ++joint)
@@ -273,9 +293,9 @@ bool RuckigSmoothing::checkForLaggingMotion(const size_t num_dof, const ruckig::
   return false;
 }
 
-void RuckigSmoothing::getNextRuckigInput(const ruckig::OutputParameter<0>& ruckig_output,
+void RuckigSmoothing::getNextRuckigInput(const ruckig::OutputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_output,
                                          const moveit::core::RobotStatePtr& next_waypoint, size_t num_dof,
-                                         const std::vector<int>& idx, ruckig::InputParameter<0>& ruckig_input)
+                                         const std::vector<int>& idx, ruckig::InputParameter<RUCKIG_DYNAMIC_DOF>& ruckig_input)
 {
   // TODO(andyz): https://github.com/ros-planning/moveit2/issues/766
   // ruckig_output.pass_to_input(ruckig_input);

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -152,14 +152,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
         }
 
         // decrease target velocity
-        for (size_t joint = 0; joint < num_dof; ++joint)
-        {
-          ruckig_input.target_velocity.at(joint) *= 0.9;
-          // Propagate the change in velocity to acceleration, too.
-          // We don't change the position to ensure the exact target position is achieved.
-          ruckig_input.target_acceleration.at(joint) =
-              (ruckig_input.target_velocity.at(joint) - ruckig_output.new_velocity.at(joint)) / timestep;
-        }
+        decreaseTargetStateVelocity(num_dof, timestep, ruckig_input);
         velocity_magnitude = getTargetVelocityMagnitude(ruckig_input, num_dof);
         // Run Ruckig
         ruckig_result = ruckig_ptr->update(ruckig_input, ruckig_output);

--- a/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
+++ b/moveit_core/trajectory_processing/src/ruckig_traj_smoothing.cpp
@@ -167,7 +167,7 @@ bool RuckigSmoothing::applySmoothing(robot_trajectory::RobotTrajectory& trajecto
 
     // If ruckig failed, the duration of the seed trajectory likely wasn't long enough.
     // Try duration extension several times.
-    if (ruckig_result == ruckig::Result::Finished)
+    if (ruckig_result == ruckig::Result::Working)
     {
       smoothing_complete = true;
     }


### PR DESCRIPTION
This ports the minor, cosmetic improvements from https://github.com/ros-planning/moveit2/pull/1076

There shouldn't be any functional change. I ran the Jupyter plots and didn't notice any changes.  :+1: